### PR TITLE
Add person network map demo and sample data

### DIFF
--- a/memo/static/apps/map/map.css
+++ b/memo/static/apps/map/map.css
@@ -733,3 +733,42 @@ a:focus {
     font-weight: 700;
     z-index: 10000;
 }
+/* ===== Person Network Additions ===== */
+.station-label {
+    background: rgba(0, 0, 0, 0.65);
+    color: #fff;
+    border-radius: 50%;
+    width: 22px;
+    height: 22px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: 700;
+    border: 2px solid #fff;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+}
+
+.station-label span {
+    line-height: 1;
+}
+
+.popup-header {
+    margin-bottom: 0.35rem;
+}
+
+.popup-title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #1a1a1a;
+}
+
+.popup-subtitle {
+    font-size: 0.9rem;
+    color: #546e7a;
+}
+
+.popup-row {
+    margin-top: 0.2rem;
+    font-size: 0.9rem;
+}

--- a/memo/static/apps/map/person_network.html
+++ b/memo/static/apps/map/person_network.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MEMO - Personen-Netzwerkkarte</title>
+
+    <!-- Leaflet CSS -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+
+    <!-- Leaflet MarkerCluster CSS (kept for consistent marker styling) -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css" />
+
+    <!-- Custom CSS -->
+    <link rel="stylesheet" href="/memo/static/apps/map/map.css">
+</head>
+<body>
+    <div class="container">
+        <!-- Header -->
+        <header class="header">
+            <div class="header-content">
+                <h1 class="title">Digitales Memobuch</h1>
+                <p class="subtitle">Personenbezogene Netzwerk-Ansicht (Demo)</p>
+                <div class="divider"></div>
+            </div>
+        </header>
+
+        <!-- Map Container -->
+        <div id="map" class="map-container"></div>
+
+        <!-- Info Panel -->
+        <div class="info-panel">
+            <div class="info-content">
+                <h3>Über diese Ansicht</h3>
+                <p>
+                    Diese Demo zeigt die Stationen einer einzelnen Person als Netzwerk.
+                    Die Gestaltung übernimmt die Elemente der MEMO-Ausgangskarte,
+                    ergänzt um Verbindungslinien zwischen den Ereignissen.
+                </p>
+                <p>
+                    Die Daten werden aus einer separaten GeoJSON-Datei geladen und können
+                    für weitere Personen dupliziert werden. Mehrere Ereignisse am selben
+                    Ort werden durch Marker-Stacking und nummerierte Stationen sichtbar.
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Leaflet JS -->
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
+
+    <!-- Custom JS -->
+    <script src="/memo/static/apps/map/person_network.js"></script>
+</body>
+</html>

--- a/memo/static/apps/map/person_network.js
+++ b/memo/static/apps/map/person_network.js
@@ -1,0 +1,243 @@
+(function() {
+    'use strict';
+
+    const CONFIG = {
+        geojsonFile: '/memo/static/apps/map/sample_person_network.json',
+        mapCenter: [47.0707, 15.4395],
+        mapZoom: 5,
+        minZoom: 3,
+        maxZoom: 18,
+        colors: {
+            voluntary_residence: '#2196F3',
+            forced_residence: '#FF9800',
+            imprisonment: '#F44336',
+            flight: '#9C27B0',
+            death: '#000000'
+        }
+    };
+
+    const EVENT_TYPES = new Set([
+        'voluntary_residence',
+        'forced_residence',
+        'imprisonment',
+        'flight',
+        'death'
+    ]);
+
+    const state = {
+        map: null,
+        geojsonData: null,
+        markers: [],
+        connections: null
+    };
+
+    function init() {
+        initializeMap();
+        loadGeoJSONData();
+    }
+
+    function initializeMap() {
+        state.map = L.map('map', {
+            center: CONFIG.mapCenter,
+            zoom: CONFIG.mapZoom,
+            minZoom: CONFIG.minZoom,
+            maxZoom: CONFIG.maxZoom,
+            zoomControl: true
+        });
+
+        L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>',
+            subdomains: 'abcd',
+            maxZoom: CONFIG.maxZoom
+        }).addTo(state.map);
+
+        addLegend();
+    }
+
+    async function loadGeoJSONData() {
+        try {
+            const response = await fetch(CONFIG.geojsonFile);
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+
+            state.geojsonData = await response.json();
+            renderPersonNetwork();
+        } catch (error) {
+            console.error('Error loading data:', error);
+        }
+    }
+
+    function renderPersonNetwork() {
+        if (!state.geojsonData || !Array.isArray(state.geojsonData.features)) {
+            return;
+        }
+
+        const points = state.geojsonData.features
+            .filter(feature => feature.geometry && feature.geometry.type === 'Point')
+            .map((feature, index) => ({
+                index,
+                coords: [feature.geometry.coordinates[1], feature.geometry.coordinates[0]],
+                properties: feature.properties || {}
+            }));
+
+        const sortedPoints = [...points].sort((a, b) => dateScore(a.properties.date) - dateScore(b.properties.date));
+
+        addMarkers(sortedPoints);
+        addConnections(sortedPoints);
+        fitBounds(sortedPoints);
+    }
+
+    function addMarkers(points) {
+        state.markers = points.map(point => {
+            const marker = L.circleMarker(point.coords, {
+                radius: 10,
+                weight: 2,
+                color: '#FFFFFF',
+                fillColor: getEventColor(point.properties.tags),
+                fillOpacity: 0.9
+            });
+
+            marker.bindPopup(createPopupContent(point));
+            marker.addTo(state.map);
+
+            addStationLabel(marker, point.index + 1);
+
+            return marker;
+        });
+    }
+
+    function addStationLabel(marker, number) {
+        const label = L.divIcon({
+            className: 'station-label',
+            html: `<span>${number}</span>`,
+            iconSize: [20, 20]
+        });
+
+        L.marker(marker.getLatLng(), { icon: label, interactive: false }).addTo(state.map);
+    }
+
+    function addConnections(points) {
+        if (points.length < 2) {
+            return;
+        }
+
+        const latlngs = points.map(point => point.coords);
+        state.connections = L.polyline(latlngs, {
+            color: '#546E7A',
+            weight: 3,
+            opacity: 0.6,
+            dashArray: '6 4'
+        }).addTo(state.map);
+    }
+
+    function fitBounds(points) {
+        if (!points.length) {
+            return;
+        }
+
+        const bounds = L.latLngBounds(points.map(point => point.coords));
+        state.map.fitBounds(bounds, { padding: [30, 30] });
+    }
+
+    function getEventColor(tags = []) {
+        const eventType = tags.find(tag => EVENT_TYPES.has(tag));
+        return CONFIG.colors[eventType] || '#546E7A';
+    }
+
+    function createPopupContent(point) {
+        const props = point.properties;
+        const { eventTypes, victimCategories } = parseTags(props.tags);
+
+        const eventTypeLabel = eventTypes.map(type => state.geojsonData.vocab?.event_types?.[type] || type).join(', ');
+        const victimLabels = victimCategories.map(cat => state.geojsonData.vocab?.victim_category_types?.[cat] || cat).join(', ');
+
+        return `
+            <div class="popup-content">
+                <div class="popup-header">
+                    <div class="popup-title">${props.person_name || 'Unbekannte Person'}</div>
+                    <div class="popup-subtitle">Station ${point.index + 1}</div>
+                </div>
+                <div class="popup-row"><strong>Ort:</strong> ${props.place_name || 'Unbekannt'}</div>
+                <div class="popup-row"><strong>Datum:</strong> ${props.date || 'Ohne Datumsangabe'}</div>
+                ${props.event_title ? `<div class="popup-row"><strong>Ereignis:</strong> ${props.event_title}</div>` : ''}
+                ${props.event_description ? `<div class="popup-row">${props.event_description}</div>` : ''}
+                ${eventTypeLabel ? `<div class="popup-row"><strong>Typ:</strong> ${eventTypeLabel}</div>` : ''}
+                ${victimLabels ? `<div class="popup-row"><strong>Kategorie:</strong> ${victimLabels}</div>` : ''}
+            </div>
+        `;
+    }
+
+    function parseTags(tags) {
+        if (!tags || !Array.isArray(tags)) {
+            return { eventTypes: [], victimCategories: [] };
+        }
+
+        const eventTypes = [];
+        const victimCategories = [];
+
+        tags.forEach(tag => {
+            if (EVENT_TYPES.has(tag)) {
+                eventTypes.push(tag);
+            } else {
+                const mainCategory = tag.split(';')[0].trim();
+                if (mainCategory) {
+                    victimCategories.push(mainCategory);
+                }
+            }
+        });
+
+        return { eventTypes, victimCategories };
+    }
+
+    function dateScore(value) {
+        if (!value) return Number.MAX_SAFE_INTEGER;
+
+        // Try to parse dd.mm.yyyy
+        const dateMatch = value.match(/^(\d{1,2})\.(\d{1,2})\.(\d{2,4})$/);
+        if (dateMatch) {
+            const [_, d, m, y] = dateMatch;
+            return new Date(`${y}-${m}-${d}`).getTime();
+        }
+
+        // Try yyyy
+        const yearMatch = value.match(/^(\d{4})$/);
+        if (yearMatch) {
+            return new Date(`${value}-01-01`).getTime();
+        }
+
+        return Number.MAX_SAFE_INTEGER;
+    }
+
+    function addLegend() {
+        const legend = L.control({ position: 'bottomright' });
+
+        legend.onAdd = function() {
+            const div = L.DomUtil.create('div', 'map-legend');
+            div.innerHTML = `
+                <div class="legend-title">Ereignistypen</div>
+                ${Object.entries(CONFIG.colors).map(([key, color]) => `
+                    <div class="legend-item">
+                        <span class="legend-color" style="background:${color}"></span>
+                        <span>${translateEventType(key)}</span>
+                    </div>
+                `).join('')}
+            `;
+            return div;
+        };
+
+        legend.addTo(state.map);
+    }
+
+    function translateEventType(key) {
+        return {
+            voluntary_residence: 'Freiwillige Wohnadresse',
+            forced_residence: 'Erzwungene Wohnadresse',
+            imprisonment: 'Haft',
+            flight: 'Flucht',
+            death: 'Tod'
+        }[key] || key;
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+})();

--- a/memo/static/apps/map/sample_person_network.json
+++ b/memo/static/apps/map/sample_person_network.json
@@ -1,0 +1,197 @@
+{
+  "type": "FeatureCollection",
+  "vocab": {
+    "event_types": {
+      "voluntary_residence": "Letzte Freiwillige Wohnadresse",
+      "forced_residence": "Erzwungene Wohnadresse",
+      "imprisonment": "Haft",
+      "flight": "Flucht",
+      "death": "Tod"
+    },
+    "victim_category_types": {
+      "widerstand;politisch": "Widerstand, politisch",
+      "widerstand;religiös": "Widerstand, religios",
+      "widerstand;individuell": "Widerstand, individuell",
+      "widerstand;deserteure": "Widerstand, Deserteure",
+      "zeugenjehovas": "Zeugen Jehovas",
+      "jüdischeopfer;jüdisch": "Jüdische Opfer",
+      "jüdischeopfer;als Jude verfolgt": "Jüdische Opfer, als Jude verfolgt",
+      "roma": "Roma",
+      "euthanasieopfer": "Euthanasie Opfer",
+      "homosexuelleopfer": "Homosexuelle Opfer",
+      "opfernsjustiz": "Opfer der NS-Justiz",
+      "asoziale": "Asoziale",
+      "spanienkämpfer": "SpanienkämpferInnen",
+      "zwangsarbeiter": "ZwangsarbeiterInnen",
+      "alliierte": "Alliierte Soldaten",
+      "zivileopfer": "Zivile Opfer"
+    }
+  },
+  "metadata": {
+    "person_id": "memo.person.2",
+    "person_name": "Ernst Altmann",
+    "birth_date": "22.11.1910",
+    "death_date": "22.12.1938",
+    "is_youth": false,
+    "gams_link": "https://gams.uni-graz.at/o:memo.person.2",
+    "feature_count": 6
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          15.43133551,
+          47.07102645
+        ]
+      },
+      "properties": {
+        "person_id": "memo.person.2",
+        "person_name": "Ernst Altmann",
+        "tags": [
+          "voluntary_residence",
+          "jüdischeopfer;jüdisch"
+        ],
+        "place_name": "Annenstraße 9, 8020 Graz",
+        "date": null,
+        "birth_date": "22.11.1910",
+        "death_date": "22.12.1938",
+        "gender": "male",
+        "is_youth": false
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.043123,
+          32.123332
+        ]
+      },
+      "properties": {
+        "person_id": "memo.person.2",
+        "person_name": "Ernst Altmann",
+        "tags": [
+          "imprisonment",
+          "jüdischeopfer;jüdisch"
+        ],
+        "place_name": "Graz, Österreich",
+        "date": "1932",
+        "birth_date": "22.11.1910",
+        "death_date": "22.12.1938",
+        "gender": "male",
+        "is_youth": false,
+        "event_id": "memo.person.2_event_haft_0",
+        "event_title": "Haft in Frankreich",
+        "event_description": "Wurde gefangen genommen..."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          32.123321,
+          32.1233221
+        ]
+      },
+      "properties": {
+        "person_id": "memo.person.2",
+        "person_name": "Ernst Altmann",
+        "tags": [
+          "imprisonment",
+          "jüdischeopfer;jüdisch"
+        ],
+        "place_name": "Ottawa, Kanada",
+        "date": "1944",
+        "birth_date": "22.11.1910",
+        "death_date": "22.12.1938",
+        "gender": "male",
+        "is_youth": false,
+        "event_id": "memo.person.2_event_haft_1",
+        "event_title": "Haft in Bruck an der Mur",
+        "event_description": "Im Gefängnis von ..."
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.043123,
+          32.123332
+        ]
+      },
+      "properties": {
+        "person_id": "memo.person.2",
+        "person_name": "Ernst Altmann",
+        "tags": [
+          "flight",
+          "jüdischeopfer;jüdisch"
+        ],
+        "place_name": "Graz, Österreich",
+        "date": "1932",
+        "birth_date": "22.11.1910",
+        "death_date": "22.12.1938",
+        "gender": "male",
+        "is_youth": false,
+        "event_id": "memo.person.2_event_flucht_0",
+        "event_title": "Flucht nach Frankreich",
+        "event_description": "Ist geflohen von X nach Y"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          32.123321,
+          32.1233221
+        ]
+      },
+      "properties": {
+        "person_id": "memo.person.2",
+        "person_name": "Ernst Altmann",
+        "tags": [
+          "flight",
+          "jüdischeopfer;jüdisch"
+        ],
+        "place_name": "Ottawa, Kanada",
+        "date": "1944",
+        "birth_date": "22.11.1910",
+        "death_date": "22.12.1938",
+        "gender": "male",
+        "is_youth": false,
+        "event_id": "memo.person.2_event_flucht_1",
+        "event_title": "Flucht von Bruck an der Mur",
+        "event_description": "Ist geflohen von X nach B"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.46869264,
+          48.26883841
+        ]
+      },
+      "properties": {
+        "person_id": "memo.person.2",
+        "person_name": "Ernst Altmann",
+        "tags": [
+          "death",
+          "jüdischeopfer;jüdisch"
+        ],
+        "place_name": "KZ Dachau",
+        "date": "22.12.1938",
+        "birth_date": "22.11.1910",
+        "death_date": "22.12.1938",
+        "gender": "male",
+        "is_youth": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add standalone person-network demo page that reuses the existing map styling
- implement a Leaflet-based network renderer with chronological connections and station labels
- provide sample GeoJSON data and CSS tweaks for the demo markers and popups

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693156c71adc8329951ce1392ff71812)