### PR TITLE
Highlight start station and show person name in network view

### DIFF
--- a/memo/static/apps/map/map.css
+++ b/memo/static/apps/map/map.css
@@ -749,6 +749,24 @@ a:focus {
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
 }
 
+.station-label--start {
+    background: linear-gradient(135deg, #FFE082 0%, #FFB300 100%);
+    color: #000;
+    border-color: #000;
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.35), 0 6px 14px rgba(0, 0, 0, 0.45);
+}
+
+.start-marker {
+    filter: drop-shadow(0 0 8px rgba(255, 179, 0, 0.7));
+    animation: startPulse 1.8s ease-in-out infinite;
+}
+
+@keyframes startPulse {
+    0% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.08); opacity: 0.8; }
+    100% { transform: scale(1); opacity: 1; }
+}
+
 .station-label span {
     line-height: 1;
 }

--- a/memo/static/apps/map/person_network.html
+++ b/memo/static/apps/map/person_network.html
@@ -21,7 +21,7 @@
         <header class="header">
             <div class="header-content">
                 <h1 class="title">Digitales Memobuch</h1>
-                <p class="subtitle">Personenbezogene Netzwerk-Ansicht (Demo)</p>
+                <p class="subtitle" id="person-network-title">Personenbezogene Netzwerk-Ansicht</p>
                 <div class="divider"></div>
             </div>
         </header>

--- a/memo/static/apps/map/person_network.js
+++ b/memo/static/apps/map/person_network.js
@@ -62,6 +62,7 @@
             }
 
             state.geojsonData = await response.json();
+            updatePageTitle();
             renderPersonNetwork();
         } catch (error) {
             console.error('Error loading data:', error);
@@ -89,11 +90,13 @@
     }
 
     function addMarkers(points) {
-        state.markers = points.map(point => {
+        state.markers = points.map((point, idx) => {
+            const isStart = idx === 0;
             const marker = L.circleMarker(point.coords, {
-                radius: 10,
-                weight: 2,
+                radius: isStart ? 12 : 10,
+                weight: isStart ? 3 : 2,
                 color: '#FFFFFF',
+                className: isStart ? 'start-marker' : '',
                 fillColor: getEventColor(point.properties.tags),
                 fillOpacity: 0.9
             });
@@ -101,15 +104,15 @@
             marker.bindPopup(createPopupContent(point));
             marker.addTo(state.map);
 
-            addStationLabel(marker, point.index + 1);
+            addStationLabel(marker, point.index + 1, isStart);
 
             return marker;
         });
     }
 
-    function addStationLabel(marker, number) {
+    function addStationLabel(marker, number, isStart = false) {
         const label = L.divIcon({
-            className: 'station-label',
+            className: `station-label${isStart ? ' station-label--start' : ''}`,
             html: `<span>${number}</span>`,
             iconSize: [20, 20]
         });
@@ -143,6 +146,17 @@
     function getEventColor(tags = []) {
         const eventType = tags.find(tag => EVENT_TYPES.has(tag));
         return CONFIG.colors[eventType] || '#546E7A';
+    }
+
+    function updatePageTitle() {
+        const titleElement = document.getElementById('person-network-title');
+        if (!titleElement) return;
+
+        const personName = state.geojsonData?.metadata?.person_name
+            || state.geojsonData?.features?.[0]?.properties?.person_name
+            || 'Unbekannte Person';
+
+        titleElement.textContent = `Personenbezogene Netzwerk-Ansicht: ${personName}`;
     }
 
     function createPopupContent(point) {


### PR DESCRIPTION
## Summary
- highlight the first station marker and label for person network maps
- animate the starting point marker to stand out on load
- load the viewed person's name into the network view subtitle dynamically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69316068f1b88329a652c3568b89df2b)