### PR TITLE
Fix person network map standalone rendering

### DIFF
--- a/memo/static/apps/map/person_network.css
+++ b/memo/static/apps/map/person_network.css
@@ -30,10 +30,6 @@
     0% { transform: scale(1); opacity: 1; }
     50% { transform: scale(1.08); opacity: 0.8; }
     100% { transform: scale(1); opacity: 1; }
-    background: linear-gradient(135deg, #FFCA28 0%, #FFB300 100%);
-    color: #000;
-    border-color: #000;
-    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.35), 0 3px 10px rgba(0, 0, 0, 0.35);
 }
 
 .station-label span {

--- a/memo/static/apps/map/person_network.html
+++ b/memo/static/apps/map/person_network.html
@@ -14,6 +14,7 @@
 
     <!-- Custom CSS -->
     <link rel="stylesheet" href="/memo/static/apps/map/map.css">
+    <link rel="stylesheet" href="/memo/static/apps/map/person_network.css">
 </head>
 <body>
     <div class="container">

--- a/memo/static/apps/map/person_network.js
+++ b/memo/static/apps/map/person_network.js
@@ -90,15 +90,6 @@
     }
 
     function addMarkers(points) {
-        state.markers = points.map(point => {
-            const isVoluntaryResidence = Array.isArray(point.properties.tags)
-                && point.properties.tags.includes('voluntary_residence');
-
-            const marker = L.circleMarker(point.coords, {
-                radius: isVoluntaryResidence ? 14 : 10,
-                weight: isVoluntaryResidence ? 3 : 2,
-                color: '#FFFFFF',
-                className: isVoluntaryResidence ? 'voluntary-marker' : '',
         state.markers = points.map((point, idx) => {
             const isStart = idx === 0;
             const marker = L.circleMarker(point.coords, {
@@ -110,10 +101,10 @@
                 fillOpacity: 0.9
             });
 
-            marker.bindPopup(createPopupContent(point));
+            marker.bindPopup(createPopupContent({ ...point, index: idx }));
             marker.addTo(state.map);
 
-            addStationLabel(marker, point.index + 1, isStart);
+            addStationLabel(marker, idx + 1, isStart);
 
             return marker;
         });


### PR DESCRIPTION
## Summary
- fix the person network map script so markers, labels, and connections render correctly and independently of the main map
- clean up the person network styles and ensure the dedicated stylesheet is loaded with the page

## Testing
- Not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693164472dd48329a35479b0eaa7d286)