### PR TITLE
Improve person network styling and navigation

### DIFF
--- a/memo/static/apps/map_personen/person_network.css
+++ b/memo/static/apps/map_personen/person_network.css
@@ -1,4 +1,8 @@
 /* ===== Person Network Styles ===== */
+.map-wrap {
+    position: relative;
+}
+
 .start-marker {
     filter: drop-shadow(0 0 8px rgba(33, 150, 243, 0.45));
     opacity: 1;
@@ -37,6 +41,142 @@
     transform: translateY(1px);
 }
 
+.journey-panel {
+    position: absolute;
+    left: 50%;
+    bottom: 24px;
+    transform: translateX(-50%);
+    width: min(1100px, calc(100% - 48px));
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 12px 45px rgba(0, 0, 0, 0.18);
+    border-radius: 18px;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    backdrop-filter: blur(4px);
+    overflow: hidden;
+    z-index: 500;
+}
+
+.journey-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.5rem;
+    padding: 1rem 1.25rem 0.5rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.journey-eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+    color: #546e7a;
+    margin-bottom: 0.1rem;
+}
+
+.journey-title {
+    font-size: 1.2rem;
+    font-weight: 800;
+    color: #1a1a1a;
+}
+
+.journey-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.journey-btn {
+    border: 1px solid #cfd8dc;
+    background: #fff;
+    color: #1a1a1a;
+    border-radius: 12px;
+    padding: 0.45rem 0.85rem;
+    cursor: pointer;
+    font-weight: 600;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+    transition: all 0.2s ease;
+}
+
+.journey-btn:hover {
+    background: #eceff1;
+    border-color: #b0bec5;
+}
+
+.journey-progress {
+    font-weight: 700;
+    color: #37474f;
+    min-width: 58px;
+    text-align: center;
+}
+
+.journey-list {
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 0.75rem;
+    padding: 0.85rem 1rem 1.1rem;
+}
+
+.journey-item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.65rem;
+    padding: 0.75rem;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    background: #fff;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.journey-item:hover {
+    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.08);
+    transform: translateY(-2px);
+}
+
+.journey-item.is-active {
+    border-color: #1a1a1a;
+    background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.12);
+}
+
+.journey-item__marker {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    border: 2px solid #fff;
+    background: var(--marker-color, #2196f3);
+    color: #fff;
+    display: grid;
+    place-items: center;
+    font-weight: 800;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
+}
+
+.journey-item__title {
+    font-weight: 700;
+    color: #1a1a1a;
+    line-height: 1.35;
+}
+
+.journey-item__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+    color: #607d8b;
+    margin-top: 0.15rem;
+}
+
+.journey-item__meta .pill {
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    background: rgba(0, 0, 0, 0.04);
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    color: #37474f;
+    font-weight: 600;
+}
+
 .popup-header {
     margin-bottom: 0.35rem;
 }
@@ -55,4 +195,75 @@
 .popup-row {
     margin-top: 0.2rem;
     font-size: 0.9rem;
+}
+
+.network-marker {
+    position: relative;
+    width: 36px;
+    height: 36px;
+}
+
+.network-marker__halo {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0) 70%);
+    transform: scale(1.2);
+}
+
+.network-marker__dot {
+    position: absolute;
+    inset: 4px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--marker-color, #2196f3) 0%, #102027 100%);
+    border: 2px solid #ffffff;
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+    transform: scale(1);
+    transition: transform 0.2s ease;
+}
+
+.network-marker__label {
+    position: absolute;
+    bottom: -10px;
+    left: 50%;
+    transform: translateX(-50%);
+    min-width: 24px;
+    height: 22px;
+    border-radius: 999px;
+    background: #1a1a1a;
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 800;
+    display: grid;
+    place-items: center;
+    padding: 0 6px;
+    box-shadow: 0 3px 8px rgba(0, 0, 0, 0.18);
+}
+
+.network-marker--start .network-marker__dot {
+    transform: scale(1.1);
+    box-shadow: 0 10px 24px rgba(33, 150, 243, 0.5);
+}
+
+.network-marker.is-active .network-marker__dot {
+    transform: scale(1.15);
+}
+
+.leaflet-pane svg .route-line {
+    filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.25));
+}
+
+@media (max-width: 900px) {
+    .journey-panel {
+        position: relative;
+        transform: none;
+        left: auto;
+        bottom: auto;
+        margin: 12px;
+    }
+
+    .map-container {
+        height: 60vh;
+        min-height: 400px;
+    }
 }

--- a/memo/static/apps/map_personen/person_network.html
+++ b/memo/static/apps/map_personen/person_network.html
@@ -28,7 +28,12 @@
         </header>
 
         <!-- Map Container -->
-        <div id="map" class="map-container"></div>
+        <div class="map-wrap">
+            <div id="map" class="map-container"></div>
+
+            <!-- Journey Panel -->
+            <section id="journey-panel" class="journey-panel" aria-label="Stationenübersicht"></section>
+        </div>
 
         <!-- Info Panel -->
         <div class="info-panel">

--- a/memo/static/apps/map_personen/person_network.js
+++ b/memo/static/apps/map_personen/person_network.js
@@ -91,18 +91,26 @@
         addConnections(orderedPoints);
         fitBounds(orderedPoints);
         addNavigationControl();
+        renderJourneyPanel(orderedPoints);
+        setActiveStation(0);
     }
 
     function addMarkers(points) {
         state.markers = points.map((point, idx) => {
             const isStart = idx === 0;
-            const marker = L.circleMarker(point.coords, {
-                radius: isStart ? 13 : 10,
-                weight: isStart ? 4 : 2,
-                color: '#ffffff',
-                className: isStart ? 'start-marker' : '',
-                fillColor: getEventColor(point.properties.tags),
-                fillOpacity: 0.95
+            const eventColor = getEventColor(point.properties.tags);
+            const marker = L.marker(point.coords, {
+                icon: L.divIcon({
+                    className: `network-marker ${isStart ? 'network-marker--start' : ''}`,
+                    html: `
+                        <div class="network-marker__halo"></div>
+                        <div class="network-marker__dot" style="--marker-color:${eventColor}"></div>
+                        <div class="network-marker__label">${idx + 1}</div>
+                    `,
+                    iconSize: [38, 44],
+                    iconAnchor: [19, 19],
+                    popupAnchor: [0, -14]
+                })
             });
 
             marker.bindPopup(createPopupContent({ ...point, index: idx }));
@@ -120,9 +128,12 @@
 
         const latlngs = points.map(point => point.coords);
         state.connections = L.polyline(latlngs, {
-            color: '#37474F',
-            weight: 4,
-            opacity: 0.75
+            color: '#263238',
+            weight: 5,
+            opacity: 0.8,
+            dashArray: '8 12',
+            lineCap: 'round',
+            className: 'route-line'
         }).addTo(state.map);
     }
 
@@ -142,6 +153,8 @@
         const marker = state.markers[index];
         marker.openPopup();
         state.map.panTo(marker.getLatLng(), { animate: true });
+        highlightMarker(index);
+        updateJourneyPanel(index);
     }
 
     function addNavigationControl() {
@@ -182,6 +195,13 @@
     function getEventColor(tags = []) {
         const eventType = tags.find(tag => EVENT_TYPES.has(tag));
         return CONFIG.colors[eventType] || '#546E7A';
+    }
+
+    function getEventLabel(tags = []) {
+        const { eventTypes } = parseTags(tags);
+        const eventType = eventTypes[0];
+        if (!eventType) return 'Ereignis';
+        return state.geojsonData.vocab?.event_types?.[eventType] || translateEventType(eventType);
     }
 
     function updatePageTitle() {
@@ -310,6 +330,81 @@
         };
 
         legend.addTo(state.map);
+    }
+
+    function highlightMarker(index) {
+        state.markers.forEach((marker, idx) => {
+            const element = marker.getElement();
+            if (element) {
+                element.classList.toggle('is-active', idx === index);
+            }
+        });
+    }
+
+    function renderJourneyPanel(points) {
+        const panel = document.getElementById('journey-panel');
+        if (!panel) return;
+
+        const personName = state.geojsonData?.metadata?.person_name
+            || state.geojsonData?.features?.[0]?.properties?.person_name
+            || 'Unbekannte Person';
+
+        panel.innerHTML = `
+            <div class="journey-header">
+                <div>
+                    <div class="journey-eyebrow">Stationen</div>
+                    <div class="journey-title">${personName}</div>
+                </div>
+                <div class="journey-controls">
+                    <button class="journey-btn" type="button" data-step="-1" aria-label="Vorherige Station">Zurück</button>
+                    <span class="journey-progress"><span id="journey-current">1</span> / ${points.length}</span>
+                    <button class="journey-btn" type="button" data-step="1" aria-label="Nächste Station">Weiter</button>
+                </div>
+            </div>
+            <ol class="journey-list">
+                ${points.map((point, idx) => `
+                    <li class="journey-item" data-index="${idx}">
+                        <div class="journey-item__marker" style="--marker-color:${getEventColor(point.properties.tags)}">${idx + 1}</div>
+                        <div class="journey-item__content">
+                            <div class="journey-item__title">${point.properties.place_name || 'Unbekannter Ort'}</div>
+                            <div class="journey-item__meta">
+                                <span class="pill">${getEventLabel(point.properties.tags)}</span>
+                                <span>${point.properties.date || 'Ohne Datum'}</span>
+                            </div>
+                        </div>
+                    </li>
+                `).join('')}
+            </ol>
+        `;
+
+        panel.querySelectorAll('.journey-btn').forEach(button => {
+            button.addEventListener('click', (event) => {
+                event.stopPropagation();
+                const step = Number(button.dataset.step) || 0;
+                goToStation(step);
+            });
+        });
+
+        panel.querySelectorAll('.journey-item').forEach(item => {
+            item.addEventListener('click', () => {
+                const targetIndex = Number(item.dataset.index);
+                setActiveStation(targetIndex);
+            });
+        });
+    }
+
+    function updateJourneyPanel(index) {
+        const progressEl = document.getElementById('journey-current');
+        if (progressEl) {
+            progressEl.textContent = String(index + 1);
+        }
+
+        document.querySelectorAll('.journey-item').forEach((item, idx) => {
+            item.classList.toggle('is-active', idx === index);
+            if (idx === index) {
+                item.scrollIntoView({ block: 'nearest', inline: 'center', behavior: 'smooth' });
+            }
+        });
     }
 
     function translateEventType(key) {


### PR DESCRIPTION
## Summary
- add an overlaid journey panel to list stations and provide navigation controls
- restyle person network markers and connecting line for a cleaner presentation
- synchronize map interactions with the journey panel so events can be clicked through sequentially

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693172420d348329bf90ad80f38c9a5a)