### PR TITLE
Ensure person network uses correct start/end ordering

### DIFF
--- a/memo/static/apps/map_personen/person_network.css
+++ b/memo/static/apps/map_personen/person_network.css
@@ -199,43 +199,35 @@
 
 .network-marker {
     position: relative;
-    width: 40px;
-    height: 40px;
+    width: 24px;
+    height: 24px;
 }
 
-.network-marker__halo {
-    position: absolute;
-    inset: 0;
+.network-marker__circle {
+    width: 100%;
+    height: 100%;
     border-radius: 50%;
-    background: radial-gradient(circle, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0) 70%);
-    transform: scale(1.25);
-}
-
-.network-marker__core {
-    position: absolute;
-    inset: 4px;
-    border-radius: 50%;
-    background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.35) 0%, transparent 50%),
-        linear-gradient(135deg, var(--marker-color, #2196f3) 0%, #0f172a 100%);
+    background: var(--marker-color, #2196f3);
     border: 2px solid #ffffff;
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
-    color: #fff;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
     display: grid;
     place-items: center;
     font-weight: 800;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
-    transform: scale(1);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    color: #fff;
+    line-height: 1;
 }
 
-.network-marker--start .network-marker__core {
-    transform: scale(1.05);
-    box-shadow: 0 10px 24px rgba(33, 150, 243, 0.5);
+.network-marker__label {
+    font-size: 0.8rem;
 }
 
-.network-marker.is-active .network-marker__core {
-    transform: scale(1.15);
-    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+.network-marker--start .network-marker__circle {
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.3), 0 6px 18px rgba(0, 0, 0, 0.35);
+}
+
+.network-marker.is-active .network-marker__circle {
+    transform: scale(1.08);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.3);
 }
 
 .leaflet-pane svg .route-line {

--- a/memo/static/apps/map_personen/person_network.js
+++ b/memo/static/apps/map_personen/person_network.js
@@ -98,18 +98,9 @@
     function addMarkers(points) {
         state.markers = points.map((point, idx) => {
             const isStart = idx === 0;
-            const eventColor = getEventColor(point.properties.tags);
+            const eventType = getPrimaryEventType(point.properties.tags);
             const marker = L.marker(point.coords, {
-                icon: L.divIcon({
-                    className: `network-marker ${isStart ? 'network-marker--start' : ''}`,
-                    html: `
-                        <div class="network-marker__halo"></div>
-                        <div class="network-marker__core" style="--marker-color:${eventColor}">${idx + 1}</div>
-                    `,
-                    iconSize: [42, 42],
-                    iconAnchor: [21, 21],
-                    popupAnchor: [0, -18]
-                })
+                icon: createStationIcon(eventType, idx, isStart)
             });
 
             marker.bindPopup(createPopupContent({ ...point, index: idx }));
@@ -192,8 +183,12 @@
     }
 
     function getEventColor(tags = []) {
-        const eventType = tags.find(tag => EVENT_TYPES.has(tag));
+        const eventType = getPrimaryEventType(tags);
         return CONFIG.colors[eventType] || '#546E7A';
+    }
+
+    function getPrimaryEventType(tags = []) {
+        return tags?.find(tag => EVENT_TYPES.has(tag));
     }
 
     function getEventLabel(tags = []) {
@@ -286,7 +281,8 @@
             ...point,
             _sortScore: dateScore(point.properties.date),
             _originalIndex: index,
-            _isDeath: (point.properties.tags || []).includes('death')
+            _isDeath: (point.properties.tags || []).includes('death'),
+            _isVoluntaryResidence: (point.properties.tags || []).includes('voluntary_residence')
         }));
 
         const sortChronologically = (a, b) => {
@@ -304,11 +300,45 @@
             .filter(point => point._isDeath)
             .sort(sortChronologically);
 
-        return [...nonDeathPoints, ...deathPoints].map(point => ({
+        let ordered = [...nonDeathPoints, ...deathPoints];
+
+        const voluntaryCandidates = ordered.filter(point => point._isVoluntaryResidence);
+        if (voluntaryCandidates.length > 0) {
+            const startCandidate = voluntaryCandidates.reduce((latest, current) => {
+                if (!latest) return current;
+                if (current._sortScore !== latest._sortScore) {
+                    return current._sortScore > latest._sortScore ? current : latest;
+                }
+                return current._originalIndex > latest._originalIndex ? current : latest;
+            }, null);
+
+            ordered = [
+                startCandidate,
+                ...ordered.filter(point => point !== startCandidate)
+            ];
+        }
+
+        return ordered.map(point => ({
             index: point.index,
             coords: point.coords,
             properties: point.properties
         }));
+    }
+
+    function createStationIcon(eventType, idx, isStart) {
+        const color = CONFIG.colors[eventType] || '#546E7A';
+
+        return L.divIcon({
+            className: `network-marker ${isStart ? 'network-marker--start' : ''}`,
+            html: `
+                <div class="network-marker__circle" style="--marker-color:${color}">
+                    <span class="network-marker__label">${idx + 1}</span>
+                </div>
+            `,
+            iconSize: [24, 24],
+            iconAnchor: [12, 12],
+            popupAnchor: [0, -10]
+        });
     }
 
     function addLegend() {


### PR DESCRIPTION
## Summary
- ensure the last voluntary residence is always used as the starting station while keeping death events last
- align person network markers with station view coloring and centered icons

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69317761f304832993a4b12a4d66da41)